### PR TITLE
Skip Git message

### DIFF
--- a/lib/git_diff_parser/patch.rb
+++ b/lib/git_diff_parser/patch.rb
@@ -4,6 +4,7 @@ module GitDiffParser
     RANGE_INFORMATION_LINE = /^@@ .+\+(?<line_number>\d+),/
     MODIFIED_LINE = /^\+(?!\+|\+)/
     NOT_REMOVED_LINE = /^[^-]/
+    NO_NEWLINE_MESSAGE = /^\\ No newline at end of file$/
 
     attr_accessor :file, :body, :secure_hash
     # @!attribute [rw] file
@@ -60,6 +61,8 @@ module GitDiffParser
         case content
         when RANGE_INFORMATION_LINE
           line_number = Regexp.last_match[:line_number].to_i
+        when NO_NEWLINE_MESSAGE
+          # nop
         when MODIFIED_LINE
           line = Line.new(
             content: content,

--- a/spec/git_diff_parser/patch_spec.rb
+++ b/spec/git_diff_parser/patch_spec.rb
@@ -39,6 +39,17 @@ module GitDiffParser
       end
     end
 
+    context "Newline inserted at EOF" do
+      describe "changed_line_numbers" do
+        it "returns changed line number" do
+          patch_body = File.read('spec/support/fixtures/file4.diff')
+          patch = Patch.new(patch_body)
+
+          expect(patch.changed_line_numbers).to eq [4]
+        end
+      end
+    end
+
     describe '#find_patch_position_by_line_number' do
       it 'returns patch position that were included' do
         patch_body = File.read('spec/support/fixtures/patch.diff')

--- a/spec/support/fixtures/file4.diff
+++ b/spec/support/fixtures/file4.diff
@@ -1,0 +1,7 @@
+@@ -1,4 +1,4 @@
+ 1
+ 2
+ 3
+-File1
+\ No newline at end of file
++File1 v2


### PR DESCRIPTION
`\ No newline at end of file` is inserted when the file does not contain LF at EOF. Ignore the message to count line numbers correctly.